### PR TITLE
allow zooming in the profiler timeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"path-parse": "^1.0.7",
 				"vue": "^2.6.14",
 				"vue-router": "^3.5.4",
+				"vue-slider-component": "^3.2.15",
 				"vuex": "^3.6.2"
 			},
 			"devDependencies": {
@@ -14893,6 +14894,14 @@
 			"resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
 			"integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
 		},
+		"node_modules/vue-class-component": {
+			"version": "7.2.6",
+			"resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.6.tgz",
+			"integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w==",
+			"peerDependencies": {
+				"vue": "^2.0.0"
+			}
+		},
 		"node_modules/vue-color": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/vue-color/-/vue-color-2.8.1.tgz",
@@ -15031,6 +15040,17 @@
 			"resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.4.6.tgz",
 			"integrity": "sha512-xo0CEVdkjSjhJoDdLSvoZoQrw/H2BlzB5jrCBKGZNXN2zdZgMuZ9BKrxXDjNP2AxlcCoKc8OahI3F3r3JGLv2Q=="
 		},
+		"node_modules/vue-property-decorator": {
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-8.5.1.tgz",
+			"integrity": "sha512-O6OUN2OMsYTGPvgFtXeBU3jPnX5ffQ9V4I1WfxFQ6dqz6cOUbR3Usou7kgFpfiXDvV7dJQSFcJ5yUPgOtPPm1Q==",
+			"dependencies": {
+				"vue-class-component": "^7.1.0"
+			},
+			"peerDependencies": {
+				"vue": "*"
+			}
+		},
 		"node_modules/vue-resize": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-1.0.1.tgz",
@@ -15046,6 +15066,15 @@
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.4.tgz",
 			"integrity": "sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ=="
+		},
+		"node_modules/vue-slider-component": {
+			"version": "3.2.15",
+			"resolved": "https://registry.npmjs.org/vue-slider-component/-/vue-slider-component-3.2.15.tgz",
+			"integrity": "sha512-FpmMsQ6MQFn22B6boDcEjRmuawdaHwjHRVZiuv5w37jijHra6+HogjSrh3mb42jE+PUIFFagXi36oFEzpDbadg==",
+			"dependencies": {
+				"core-js": "^3.6.5",
+				"vue-property-decorator": "^8.0.0"
+			}
 		},
 		"node_modules/vue-style-loader": {
 			"version": "4.1.3",
@@ -27448,6 +27477,12 @@
 			"resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
 			"integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
 		},
+		"vue-class-component": {
+			"version": "7.2.6",
+			"resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.6.tgz",
+			"integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w==",
+			"requires": {}
+		},
 		"vue-color": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/vue-color/-/vue-color-2.8.1.tgz",
@@ -27548,6 +27583,14 @@
 			"resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.4.6.tgz",
 			"integrity": "sha512-xo0CEVdkjSjhJoDdLSvoZoQrw/H2BlzB5jrCBKGZNXN2zdZgMuZ9BKrxXDjNP2AxlcCoKc8OahI3F3r3JGLv2Q=="
 		},
+		"vue-property-decorator": {
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-8.5.1.tgz",
+			"integrity": "sha512-O6OUN2OMsYTGPvgFtXeBU3jPnX5ffQ9V4I1WfxFQ6dqz6cOUbR3Usou7kgFpfiXDvV7dJQSFcJ5yUPgOtPPm1Q==",
+			"requires": {
+				"vue-class-component": "^7.1.0"
+			}
+		},
 		"vue-resize": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-1.0.1.tgz",
@@ -27560,6 +27603,15 @@
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.4.tgz",
 			"integrity": "sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ=="
+		},
+		"vue-slider-component": {
+			"version": "3.2.15",
+			"resolved": "https://registry.npmjs.org/vue-slider-component/-/vue-slider-component-3.2.15.tgz",
+			"integrity": "sha512-FpmMsQ6MQFn22B6boDcEjRmuawdaHwjHRVZiuv5w37jijHra6+HogjSrh3mb42jE+PUIFFagXi36oFEzpDbadg==",
+			"requires": {
+				"core-js": "^3.6.5",
+				"vue-property-decorator": "^8.0.0"
+			}
 		},
 		"vue-style-loader": {
 			"version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"nextcloud-server": "^0.15.10",
 		"path-parse": "^1.0.7",
 		"vue": "^2.6.14",
+		"vue-slider-component": "^3.2.15",
 		"vue-router": "^3.5.4",
 		"vuex": "^3.6.2"
 	},

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -1,0 +1,147 @@
+<!--
+SPDX-FileCopyrightText: 2022 Robin Appelman <robin@icewind.nl>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="timeline">
+		<div class="slider">
+			<VueSlider v-model="range"
+				:min="0"
+				:max="duration"
+				:interval="0.1" />
+		</div>
+		<div class="zoom-container" :style="zoomStyle">
+			<TimelineNode :event="eventTree" @click="(event) => range = [toMs(event.start, true), toMs(event.stop)]" />
+		</div>
+	</div>
+</template>
+
+<script>
+import TimelineNode from './TimelineNode'
+import VueSlider from 'vue-slider-component'
+import 'vue-slider-component/theme/antd.css'
+
+/**
+ *
+ * @param time
+ * @param low
+ */
+function toMs(time, low) {
+	if (low) {
+		return Math.floor(time * 10_000) / 10
+	} else {
+		return Math.ceil(time * 10_000) / 10
+	}
+}
+
+export default {
+	name: 'Timeline',
+	components: {
+		TimelineNode,
+		VueSlider,
+	},
+	props: {
+		events: {
+			type: Object,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			range: [0, toMs(this.events.runtime.stop - this.events.init.start)],
+		}
+	},
+	computed: {
+		zoomStyle() {
+			const duration = (this.events.runtime.stop - this.events.init.start) * 1000
+			const width = this.range[1] - this.range[0]
+			const zoom = duration / width
+			const left = this.range[0] / width
+			return `margin-left: ${-left * 100}%; width: ${zoom * 100}%`
+		},
+		duration() {
+			return toMs(this.events.runtime.stop - this.events.init.start)
+		},
+		eventTree() {
+			const runtimeStop = this.events.runtime.stop
+			const events = Object.values(this.events)
+			events.forEach(event => {
+				if (!event.stop) {
+					event.stop = runtimeStop
+				}
+			})
+			events.sort((a, b) => {
+				if (a.start < b.start) {
+					return -1
+				} else if (a.start > b.start) {
+					return 1
+				} else {
+					// if 2 events have the same start, the one that ends last should be sorted first as it is the parent
+					return b.stop - a.stop
+				}
+			})
+			const startTime = events[0].start
+			const stopTime = Math.max(...events.map(event => event.stop))
+			let current = {
+				id: 'root',
+				duration: stopTime - startTime,
+				start: 0,
+				stop: stopTime - startTime,
+				children: [],
+				childDepth: 0,
+				parents: [],
+			}
+			const stack = [current]
+
+			for (let event of events) {
+				event = {
+					id: event.id,
+					duration: event.duration,
+					start: event.start - startTime,
+					stop: event.stop - startTime,
+					description: event.description,
+					children: [],
+					childDepth: 0,
+					parents: [],
+				}
+				while (event.stop > current.stop) {
+					current = stack.pop()
+				}
+
+				current.children.push(event)
+				event.parents = [current].concat(current.parents)
+
+				if (current.childDepth === 0) {
+					let depth = 0
+					for (const parent of event.parents) {
+						depth += 1
+						parent.childDepth = Math.max(depth, parent.childDepth)
+					}
+				}
+
+				stack.push(current)
+				current = event
+			}
+
+			return stack[0]
+		},
+	},
+	methods: {
+		toMs,
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+#content div.slider * {
+	box-sizing: content-box;
+}
+
+div.zoom-container {
+	position: relative;
+	width: auto;
+	transition: width 0.5s, margin-left 0.5s;
+}
+</style>

--- a/src/components/TimelineNode.vue
+++ b/src/components/TimelineNode.vue
@@ -6,15 +6,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <template>
 	<div class="node-group">
-		<div class="node" :title="`${event.id} - ${event.description} ${duration}ms`">
+		<div class="node" :title="`${event.id} - ${event.description} ${duration}ms`" @click="$emit('click', event)">
 			{{ event.id }} - {{ event.description }} {{ duration }}ms
 		</div>
-		<div v-if="children.length > 0" class="children">
+		<div v-if="children.length > 0" class="children" :style="`height: ${childHeight}px`">
 			<div v-for="(event) in children"
 				:key="event.id"
 				:style="event.style"
 				class="child">
-				<TimelineNode :event="event" />
+				<TimelineNode :event="event" @click="(childEvent) => $emit('click', childEvent)" />
 			</div>
 		</div>
 	</div>
@@ -29,14 +29,18 @@ export default {
 			required: true,
 		},
 	},
+	emits: ['click'],
 	computed: {
 		children() {
 			return this.event.children.map(child => {
 				const startRelative = (child.start - this.event.start) / this.event.duration
 				const durationRelative = child.duration / this.event.duration
-				child.style = `left: ${startRelative * 100}%; width: ${durationRelative * 100}%`
+				child.style = `left: ${(startRelative) * 100}%; width: ${durationRelative * 100}%`
 				return child
 			})
+		},
+		childHeight() {
+			return 24 * this.event.childDepth
 		},
 		duration() {
 			return (this.event.duration * 1000).toFixed(1)
@@ -67,13 +71,14 @@ div.node {
 	background-color: #00000044;
 	padding: 0 2px;
 	white-space: nowrap;
+	cursor: pointer;
 }
 
 div.child {
-	position: relative;
+	position: absolute;
 	display: inline-block;
 	vertical-align: top;
-	top: 0;
+	//top: 0;
 	overflow-x: hidden;
 	margin: 0;
 }

--- a/src/views/EventsView.vue
+++ b/src/views/EventsView.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <template>
 	<div>
 		<h2>Events</h2>
-		<TimelineNode :event="eventTree" />
+		<Timeline v-if="events" :events="events" />
 		<div style="overflow-x:auto;">
 			<table>
 				<thead>
@@ -30,7 +30,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 						</td>
 						<td>
 							{{ (event.duration * 1000).toFixed(1) }} ms
-							(Start: {{ event.start * 1000 }}, End: {{ event.stop * 1000 }})
+							(Start: {{ (event.start - start) * 1000 }}, End: {{ (event.stop - start) * 1000 }})
 						</td>
 						<td>
 							{{ event.description }}
@@ -44,74 +44,19 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <script>
 import { mapState } from 'vuex'
-import TimelineNode from '../components/TimelineNode'
+import Timeline from '../components/Timeline'
 
 export default {
 	name: 'EventsView',
 	components: {
-		TimelineNode,
+		Timeline,
 	},
 	computed: {
 		events() {
 			return this.profiles[this.$route.params.token]?.collectors.event
 		},
-		eventTree() {
-			if (!this.profiles[this.$route.params.token]?.collectors.event) {
-				return {
-					id: 'root',
-					duration: 0,
-					start: 0,
-					stop: 0,
-					description: '',
-					children: [],
-				}
-			}
-			const runtimeStop = this.events.runtime.stop
-			const events = Object.values(this.events)
-			events.forEach(event => {
-				if (!event.stop) {
-					event.stop = runtimeStop
-				}
-			})
-			events.sort((a, b) => {
-				if (a.start < b.start) {
-					return -1
-				} else if (a.start > b.start) {
-					return 1
-				} else {
-					// if 2 events have the same start, the one that ends last should be sorted first as it is the parent
-					return b.stop - a.stop
-				}
-			})
-			const startTime = events[0].start
-			const stopTime = Math.max(...events.map(event => event.stop))
-			let current = {
-				id: 'root',
-				duration: stopTime - startTime,
-				start: 0,
-				stop: stopTime - startTime,
-				children: [],
-			}
-			const stack = [current]
-
-			for (let event of events) {
-				event = {
-					id: event.id,
-					duration: event.duration,
-					start: event.start - startTime,
-					stop: event.stop - startTime,
-					description: event.description,
-					children: [],
-				}
-				while (event.stop > current.stop) {
-					current = stack.pop()
-				}
-
-				current.children.push(event)
-				stack.push(current)
-				current = event
-			}
-			return stack[0]
+		start() {
+			return this.profiles[this.$route.params.token]?.collectors.event.init?.start
 		},
 		...mapState(['profiles']),
 	},


### PR DESCRIPTION
Allows zooming into the event timeline by either using the range select handles or by clicking on an event in the timeline

requires https://github.com/nextcloud/server/pull/32427 to prevent issues with overlapping events