### PR TITLE
fix timeline viewer when using dark mode

### DIFF
--- a/src/components/TimelineNode.vue
+++ b/src/components/TimelineNode.vue
@@ -40,7 +40,7 @@ export default {
 			})
 		},
 		childHeight() {
-			return 24 * this.event.childDepth
+			return 25 * this.event.childDepth
 		},
 		duration() {
 			return (this.event.duration * 1000).toFixed(1)
@@ -68,7 +68,8 @@ div.node, div.children {
 }
 
 div.node {
-	background-color: #00000044;
+	background-color: var(--color-loading-light);
+	margin-top: 1px;
 	padding: 0 2px;
 	white-space: nowrap;
 	cursor: pointer;
@@ -78,7 +79,6 @@ div.child {
 	position: absolute;
 	display: inline-block;
 	vertical-align: top;
-	//top: 0;
 	overflow-x: hidden;
 	margin: 0;
 }


### PR DESCRIPTION
also add a 1px border between rows to help distinguish them

Before:
![before](https://user-images.githubusercontent.com/1283854/217010330-44f827a3-6051-4bbd-a224-1b0e61a0e107.png)
After:
![after](https://user-images.githubusercontent.com/1283854/218747530-c08d57e3-49c9-417a-8a62-b08f48f79dcb.png)

Not 100% happy with the colors but acceptable while using the pre-defined vars available.

Fixes #150