### PR TITLE
show queries per event in events view

### DIFF
--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -47,6 +47,10 @@ export default {
 			type: Object,
 			required: true,
 		},
+		queries: {
+			type: Object,
+			required: true,
+		},
 	},
 	data() {
 		return {
@@ -67,6 +71,7 @@ export default {
 		eventTree() {
 			const runtimeStop = this.events.runtime.stop
 			const events = Object.values(this.events)
+			const queries = Object.values(this.queries)
 			events.forEach(event => {
 				if (!event.stop) {
 					event.stop = runtimeStop
@@ -92,6 +97,7 @@ export default {
 				children: [],
 				childDepth: 0,
 				parents: [],
+				queries,
 			}
 			const stack = [current]
 
@@ -105,6 +111,7 @@ export default {
 					children: [],
 					childDepth: 0,
 					parents: [],
+					queries: queries.filter(query => (query.start >= event.start && query.start < event.stop)),
 				}
 				while (event.stop > current.stop) {
 					current = stack.pop()

--- a/src/components/TimelineNode.vue
+++ b/src/components/TimelineNode.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <template>
 	<div class="node-group">
 		<div class="node" :title="`${event.id} - ${event.description} ${duration}ms`" @click="$emit('click', event)">
-			{{ event.id }} - {{ event.description }} {{ duration }}ms
+			{{ event.id }} - {{ event.description }} - {{ duration }}ms - {{ event.queries.length }} queries
 		</div>
 		<div v-if="children.length > 0" class="children" :style="`height: ${childHeight}px`">
 			<div v-for="(event) in children"


### PR DESCRIPTION
Provides a high level overview of where queries are coming from

- [x] requires https://github.com/nextcloud/server/pull/36698

![image](https://user-images.githubusercontent.com/1283854/218756285-b7df8e09-0697-4f3f-b017-4759008e63b2.png)

![image](https://user-images.githubusercontent.com/1283854/218756374-55ace2f1-9d89-478f-9fc1-9f3de25fb0bf.png)
