### PR TITLE
add 'logging' type for app

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,10 +9,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	<name>Profiler</name>
 	<summary>Profiler for nextcloud</summary>
 	<description><![CDATA[Provides a profiler for Nextcloud. Making developing fast apps easier.]]></description>
-	<version>1.3.0</version>
+	<version>1.3.1</version>
 	<licence>agpl</licence>
 	<author>Carl Schwan</author>
 	<namespace>Profiler</namespace>
+
+	<types>
+		<logging/>
+	</types>
 
 	<category>customization</category>
 


### PR DESCRIPTION
this ensures the app is also loaded on dav requests.

Without this only the 'db' collector is used for dav requests.