### PR TITLE
chore: update transifex link

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -20,7 +20,7 @@ If your issue appears to be a bug, and hasn't been reported, open a new issue.
 Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
 
 ## Translations
-Please submit translations via [Transifex](https://www.transifex.com/nextcloud/nextcloud/profiler/).
+Please submit translations via [Transifex](https://explore.transifex.com/nextcloud/).
 
 ## Contributing to Source Code
 


### PR DESCRIPTION
Broken link.

It's still possible to link to the resource directly like https://app.transifex.com/nextcloud/nextcloud/profiler/, however guest users are then redirected to a login page, and therefore I've opted for the project overview.