### PR TITLE
fix: handle no HTTP_USER_AGENT information for $_SERVER when running through occ

### DIFF
--- a/lib/DataCollector/HttpDataCollector.php
+++ b/lib/DataCollector/HttpDataCollector.php
@@ -32,7 +32,7 @@ class HttpDataCollector extends AbstractDataCollector {
 				'method' => $request->getMethod(),
 				'content' => $content,
 				'httpProtocol' => $request->getHttpProtocol(),
-				'userAgent' => $_SERVER['HTTP_USER_AGENT'],
+				'userAgent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
 				'params' => $content,
 			],
 			'response' => [


### PR DESCRIPTION
`console.php` loads the provider to collect with  `IRequest` even though we have no user-agent information, so let's fallback to an empty string