### PR TITLE
[stable34] Update nextcloud/ocp dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	"description": "profiler",
 	"license": "AGPL",
 	"require-dev": {
-		"nextcloud/ocp": "dev-master"
+		"nextcloud/ocp": "dev-stable34"
 	},
 	"config": {
 		"optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a549c5af345d6566f47051c1fe233cf",
+    "content-hash": "4d57646f1f13e64fb6353a5022bf0bde",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -67,16 +67,16 @@
     "packages-dev": [
         {
             "name": "nextcloud/ocp",
-            "version": "dev-master",
+            "version": "dev-stable34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "f3fddf2af92f48d3f53569074f69f0ae4bad52b6"
+                "reference": "6f7475c163404df11cde86535e3ad0b46abca5a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f3fddf2af92f48d3f53569074f69f0ae4bad52b6",
-                "reference": "f3fddf2af92f48d3f53569074f69f0ae4bad52b6",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6f7475c163404df11cde86535e3ad0b46abca5a1",
+                "reference": "6f7475c163404df11cde86535e3ad0b46abca5a1",
                 "shasum": ""
             },
             "require": {
@@ -87,11 +87,10 @@
                 "psr/http-client": "^1.0.3",
                 "psr/log": "^3.0.2"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "34.0.0-dev"
+                    "dev-stable34": "34.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -111,9 +110,9 @@
             "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/master"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable34"
             },
-            "time": "2026-05-09T01:52:54+00:00"
+            "time": "2026-05-20T02:08:51+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency