### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 	<summary>Profiler for nextcloud</summary>
 	<description><![CDATA[Provides a profiler for Nextcloud. Making developing fast apps easier.]]></description>
 	<version>6.0.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author>Carl Schwan</author>
 	<namespace>Profiler</namespace>
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	},
 	"name": "nextcloud/profiler",
 	"description": "profiler",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"require-dev": {
 		"nextcloud/ocp": "dev-master"
 	},

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,7 @@
 	findUnusedBaselineEntry="true"
 	findUnusedCode="false"
 	resolveFromConfigFile="true"
-	phpVersion="8.2"
+	phpVersion="8.3"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="https://getpsalm.org/schema/config"
 	xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"


### PR DESCRIPTION
unifying the license string, already used in package.json and supported in info.xml since 31, so no issue given min-version is set to 35 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
